### PR TITLE
Add new `rails-docker` file that uses load/overload conditionally

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0 - October 24, 2018
+
+* Support for Docker environments and EC2 environments in single file to include (`lib/dotenv/rails-docker`)
+
 [Unreleased changes](https://github.com/bkeepers/dotenv/compare/v2.2.1...master)
 
 ## 2.2.1 - Apr 28, 2017

--- a/lib/dotenv/rails-docker.rb
+++ b/lib/dotenv/rails-docker.rb
@@ -1,0 +1,9 @@
+require "dotenv/rails"
+
+# In Skyline (Docker and *NOT* the test environment)
+if File.exist?("/.dockerenv") && ENV["RAILS_ENV"] != "test"
+  Dotenv::Railtie.load
+else # Running things the old way, meaning we need the overload behaviour
+  Dotenv::Railtie.overload
+end
+

--- a/lib/dotenv/version.rb
+++ b/lib/dotenv/version.rb
@@ -1,3 +1,3 @@
 module Dotenv
-  VERSION = "2.2.2".freeze
+  VERSION = "2.3.0".freeze
 end


### PR DESCRIPTION
Add new `rails-docker` file that uses load/overload conditionally based on whether we're running in a non-test docker environment.

If we're in Docker, and *not* a test environment, we're in Skyline so we don't need to overload env vars.
Otherwise, we're in EC2 or Circle, so we want to keep the old behavior.
